### PR TITLE
Use wagmi context for Balances and UniversalKitProvider components

### DIFF
--- a/src/components/Balances/index.tsx
+++ b/src/components/Balances/index.tsx
@@ -10,7 +10,7 @@ import { roundNumber } from "@/lib/utils";
 import { useBitcoinWallet } from "@/index";
 import { useAccount, useWalletClient } from "wagmi";
 import { useEthersSigner } from "@/hooks/useEthersSigner";
-import { useZetaChainClient } from "@/providers/UniversalKitProvider";
+import { useZetaChainClient, wagmiContextValue } from "@/providers/UniversalKitProvider";
 
 interface Token {
   id: string;
@@ -22,15 +22,18 @@ interface Token {
 interface BalancesProps {
   config?: any;
   balances?: any;
+  wagmiContextValue?: wagmiContextValue;
   onBalanceClick?: (balance: Token) => void;
 }
 
 export const Balances = ({
   config,
   balances: balancesProp,
+  wagmiContextValue,
   onBalanceClick = () => {},
 }: BalancesProps) => {
-  const { address, status } = useAccount();
+  const useWagmiAccount = wagmiContextValue?.useAccount || useAccount;
+  const { address, status } = useWagmiAccount();
 
   const { address: bitcoin } = useBitcoinWallet();
   const client = useZetaChainClient();


### PR DESCRIPTION
Relevant issue: #12 

The reason for this issue is that components in universalkit cannot inherit the context of WagmiProvider from the template, which is strange as it should normally be possible.

If all the components in universal were defined within the template, this problem wouldn't exist. There could be multiple reasons causing this issue.

I've tried several methods but found that none of them could solve the problem, such as unifying the React version or using dynamic imports for components in universalkit. No matter what I did, the context of WagmiProvider in the template would be lost after passing it to components in universalkit, meaning hooks like useAccount from wagmi couldn't be used in universalkit.

A simpler and effective solution is to pass the context through parameters:

1. Use React.forwardRef and useContext, instead of directly using wagmi hooks, pass necessary functions and data via props. The advantage is direct use of WagmiContext without needing to pass each hook separately.

2. Provide an option for library components that allows users to manually inject the context of WagmiProvider. The advantage is flexibility, allowing users to selectively override certain Wagmi hooks.

I'm currently using the second method, which is more flexible. If we understand the cause of this problem in the future, we can fix it without changing the code, just reverting to the previous usage without passing any hook context.

After modification, to apply it to the template, you only need to manually inject hooks to override the default hooks. The implementation of Provider in template/web that needs to be modified is as follows:

```typescript
export const Providers = ({ children }: { children: React.ReactNode }) => {
  const [mounted, setMounted] = useState(false);
  useEffect(() => {
    setMounted(true);
  }, []);
  if (!mounted) return null;
  // add hooks
  const wagmiContextValue = {
    useAccount: useAccount as any,
    useChainId: useChainId as any,
    useWalletClient: useWalletClient as any,
  };
  return (
    <WagmiProvider config={config}>
      <QueryClientProvider client={queryClient}>
        <NextThemesProvider
          attribute="class"
          defaultTheme="system"
          enableSystem
          disableTransitionOnChange
        >
          <ThemeProvider>
            <UniversalKitProvider wagmiContextValue={wagmiContextValue}>
              {children}
            </UniversalKitProvider>
          </ThemeProvider>
        </NextThemesProvider>
      </QueryClientProvider>
    </WagmiProvider>
  );
};
```

If you want to use the Balances component in template/web/Page.tsx:

```typescript
const Page = () => {
  const wagmiContextValue = {
    useAccount: useAccount as any,
    useChainId: useChainId as any,
    useWalletClient: useWalletClient as any,
  };
  return (
    <div className="m-4">
      <div className="flex justify-end gap-2 mb-10">
        <ConnectBitcoin />
        <ConnectButton label="Connect EVM" showBalance={false} />
      </div>
      <div className="flex justify-center">
        <div className="w-[400px]">
          <Balances wagmiContextValue={wagmiContextValue} />
        </div>
      </div>
    </div>
  );
};
```