### PR TITLE
Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "dependabot: " 
+    labels:
+      - "dependencies" 
+    allow:
+      - dependency-name: "@zetachain/toolkit"
+      - dependency-name: "@zetachain/networks"
+      - dependency-name: "@zetachain/protocol-contracts"
+      - dependency-name: "@zetachain/universalkit"
+      - dependency-name: "@zetachain/localnet"
+


### PR DESCRIPTION
This configuration will enable Dependabot to create automatic PR's for defined `zetachain` related dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced Dependabot configuration for automatic daily updates of npm package dependencies.
	- Enhanced organization of pull requests with a specific commit message prefix and labels for dependency updates.
	- Targeted updates for ZetaChain-related dependencies to ensure compatibility and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->